### PR TITLE
Tweak image name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # Docker image for `rails new`
 
 ```
-docker build -t rails-new .
+cd ~/docker # or wherever you like
+git clone git@github.com:ppworks/docker-rails_new.git dev # or whatever name you like
 ```
 
 ```
-docker-compose run --rm rails rails new your-awesome-app --skip-bundle
+docker-compose run --rm rails-new rails new your-awesome-app --skip-bundle
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 version: '3'
 services:
-  rails:
+  rails-new:
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
> https://docs.docker.com/compose/compose-file/#context
Compose will build and tag it with a generated name, and use that image thereafter.

If I use **docker-rails_new** directory which is default name of `git clone {this repository}`, `docker-compose run` results will give the name as **dockerrailsnew_rails** to docker image.

I think it's redundant naming.

This PR will improve naming for docker image.

e.g.

```
cd ~/docker
git clone git@github.com:ppworks/docker-rails_new.git dev
docker-compose run --rm rails-new rails new your-awesome-app --skip-bundle
```

```
docker images
```

```
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
dev_rails-new       latest              e80dafeae115        11 minutes ago      468MB
```